### PR TITLE
Implement PoC to allow the config to configure the load precedence.

### DIFF
--- a/news/1234.feature.rst
+++ b/news/1234.feature.rst
@@ -1,0 +1,1 @@
+The config precedence can now be overridden with a special ``config-precedence`` config value

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -207,6 +207,7 @@ class ConfigurationCommand(Command):
                     write_output("%s, exists: %r", fname, file_exists)
                     if file_exists:
                         self.print_config_file_values(variant)
+        write_output("load-precedence: %s", ", ".join(self.configuration.load_order))
 
     def print_config_file_values(self, variant: Kind) -> None:
         """Get key-value pairs from the file of a variant"""
@@ -216,7 +217,7 @@ class ConfigurationCommand(Command):
 
     def print_env_var_values(self) -> None:
         """Get key-values pairs present as environment variables"""
-        write_output("%s:", "env_var")
+        write_output("%s:", "env-var")
         with indent_log():
             for key, value in sorted(self.configuration.get_environ_vars()):
                 env_var = f"PIP_{key.upper()}"

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -110,6 +110,8 @@ class Configuration:
         self.isolated = isolated
         self.load_only = load_only
 
+        self._load_order: Tuple[Kind, ...] = OVERRIDE_ORDER
+
         # Because we keep track of where we got the data from
         self._parsers: Dict[Kind, List[Tuple[str, RawConfigParser]]] = {
             variant: [] for variant in OVERRIDE_ORDER
@@ -124,6 +126,13 @@ class Configuration:
         self._load_config_files()
         if not self.isolated:
             self._load_environment_vars()
+
+    @property
+    def load_order(self) -> Tuple[Kind, ...]:
+        # The act of computing the config dictionary will result in the _load_order
+        # attribute being correctly updated.
+        _ = self._dictionary
+        return self._load_order
 
     def get_file_to_edit(self) -> Optional[str]:
         """Returns the file with highest priority in configuration"""
@@ -225,11 +234,45 @@ class Configuration:
     @property
     def _dictionary(self) -> Dict[str, Any]:
         """A dictionary representing the loaded configuration."""
+
+        # We always read the config in the default load-order first, giving
+        # us a deterministic load-order configuration value.
+        config = self._blended_config_dict(OVERRIDE_ORDER)
+
+        # Re-compose the config based on the desired override-order, if
+        # different to the default.
+        config_precedence: List[str] = (
+            str(config.get("global.config-precedence", "")).strip().splitlines()
+        )
+        if config_precedence:
+            bad_values = [
+                value
+                for value in config_precedence
+                if value not in kinds.reverse_mapping
+            ]
+            if bad_values:
+                term_or_terms = "term" if len(bad_values) == 1 else "terms"
+                raise ConfigurationError(
+                    f"Invalid config-precedence {term_or_terms} provided "
+                    f"({','.join(bad_values)}). "
+                    f"Valid values are {', '.join(map(repr, kinds.reverse_mapping))}."
+                )
+            self._load_order = tuple(
+                getattr(kinds, kinds.reverse_mapping[value])
+                for value in config_precedence
+            )
+            if self._load_order != OVERRIDE_ORDER:
+                config = self._blended_config_dict(self._load_order)
+        return config
+
+    def _blended_config_dict(
+        self, load_order: Tuple[Kind, ...] = OVERRIDE_ORDER
+    ) -> Dict[str, Any]:
         # NOTE: Dictionaries are not populated if not loaded. So, conditionals
         #       are not needed here.
         retval = {}
 
-        for variant in OVERRIDE_ORDER:
+        for variant in load_order:
             retval.update(self._config[variant])
 
         return retval


### PR DESCRIPTION
(NOTE: PR to my own fork, for discussion, but not a proposal for merging to pip yet)

Prototype of config load order configuration.


With this change, you can find the load precedence when debugging:

```
$ python -m pip config debug
env-var:
env:
global:
  /etc/xdg/xdg-ubuntu/pip/pip.conf, exists: False
  /etc/xdg/pip/pip.conf, exists: False
  /etc/pip.conf, exists: False
site:
  /media/important/github/pypa/pip/env/pip.conf, exists: True
user:
  /home/pelson/.pip/pip.conf, exists: False
  /home/pelson/.config/pip/pip.conf, exists: False
load-precedence: global, user, site, env, env-var

```

You can also influence it:

```

```
